### PR TITLE
解决潜在的中文乱码问题

### DIFF
--- a/BookStore/src/c3p0-config.xml
+++ b/BookStore/src/c3p0-config.xml
@@ -19,7 +19,7 @@
 	
 	<named-config name="mysql">
 		<property name="driverClass">com.mysql.jdbc.Driver</property>
-		<property name="jdbcUrl">jdbc:mysql://localhost:3306/bookstore</property>
+		<property name="jdbcUrl">jdbc:mysql://localhost:3306/bookstore?characterEncoding=utf8</property>
 		<property name="user">root</property>
 		<property name="password">root</property>
 		


### PR DESCRIPTION
若不添加【?characterEncoding=utf8】，则对某些中文字符仍然存在中文乱码问题。
